### PR TITLE
Add FastAPI chat API and integrate Langfuse tracing

### DIFF
--- a/Dockerfile.chat_api
+++ b/Dockerfile.chat_api
@@ -1,0 +1,11 @@
+# Dockerfile for FastAPI Chat API
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "src.backend.ai.chat_api:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/config.py
+++ b/config.py
@@ -35,6 +35,7 @@ os.makedirs(DATA_DIR, exist_ok=True)
 os.makedirs(ARCHIVE_DIR, exist_ok=True)
 os.makedirs(LOGS_DIR, exist_ok=True)
 
+
 # API Settings
 # SAM.gov API
 SAM_API_URL = "https://api.sam.gov/opportunities/v2/search"
@@ -57,6 +58,60 @@ SDMX_API_URL = "https://www.ilo.org/sdmx/rest"
 # BLS API (Bureau of Labor Statistics)
 BLS_API_URL = "https://api.bls.gov/publicAPI/v2"
 BLS_API_KEY = os.getenv("BLS_API_KEY", "048186641837463e8d5eccba12e798a4")
+
+
+# Prompt Repository (for agent/LLM prompt templates)
+def get_prompt_repo_path() -> str:
+    """
+    Get the path to the prompt repository for agent/LLM prompt templates.
+    Returns:
+        Path as a string
+    """
+    return os.getenv("PROMPT_REPO_PATH", str(Path(__file__).parent / "src" / "backend" / "ai" / "prompt_templates"))
+
+# Langfuse Observability Config
+def get_langfuse_config() -> Dict[str, Any]:
+    """
+    Get Langfuse configuration from environment variables.
+    Returns:
+        Dictionary containing Langfuse configuration parameters
+    """
+    return {
+        "LANGFUSE_PUBLIC_KEY": os.getenv("LANGFUSE_PUBLIC_KEY"),
+        "LANGFUSE_SECRET_KEY": os.getenv("LANGFUSE_SECRET_KEY"),
+        "LANGFUSE_HOST": os.getenv("LANGFUSE_HOST", "http://localhost:3000"),
+        "LANGFUSE_PROJECT": os.getenv("LANGFUSE_PROJECT", "default"),
+        "LANGFUSE_ENVIRONMENT": os.getenv("LANGFUSE_ENVIRONMENT", "development"),
+    }
+
+# Ollama LLM/AI Integration Config
+def get_ollama_config() -> Dict[str, Any]:
+    """
+    Get Ollama configuration from environment variables.
+    Returns:
+        Dictionary containing Ollama configuration parameters
+    """
+    return {
+        "OLLAMA_BASE_URL": os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
+        "OLLAMA_MODEL": os.getenv("OLLAMA_MODEL", "mistral"),
+        "TEMPERATURE": float(os.getenv("TEMPERATURE", "0.7")),
+        "MAX_TOKENS": int(os.getenv("MAX_TOKENS", "2000")),
+    }
+
+# Placeholders for future MCP/AI agent config
+def get_mcp_config() -> Dict[str, Any]:
+    """
+    Get MCP/AI agent configuration from environment variables.
+    Returns:
+        Dictionary containing MCP/AI agent configuration parameters
+    """
+    return {
+        "MCP_SERVER_URL": os.getenv("MCP_SERVER_URL", "http://localhost:8000"),
+        "MCP_API_KEY": os.getenv("MCP_API_KEY", ""),
+        "PYDANTIC_AI_MODEL": os.getenv("PYDANTIC_AI_MODEL", "mistral"),
+    }
+
+# Reason: Centralizes all AI/LLM/MCP config for easy access and validation
 
 # Rate limiting management for SAM.gov
 SAM_API_RATE_LIMIT = int(os.getenv("SAM_API_RATE_LIMIT", "5").split('#')[0].strip())  # Requests per minute allowed
@@ -187,7 +242,7 @@ def get_ollama_config() -> Dict[str, Any]:
     """
     return {
         "OLLAMA_BASE_URL": os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
-        "OLLAMA_MODEL": os.getenv("OLLAMA_MODEL", "llama2"),
+        "OLLAMA_MODEL": os.getenv("OLLAMA_MODEL", "mistral"),
         "TEMPERATURE": float(os.getenv("TEMPERATURE", "0.7")),
         "MAX_TOKENS": int(os.getenv("MAX_TOKENS", "2000"))
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+# Data_Insights Docker Compose
+# Adds FastAPI chat API to the stack for LLM/agent chat
+
+version: "3.8"
+
+services:
+  chat-api:
+    build:
+      context: .
+      dockerfile: Dockerfile.chat_api
+    container_name: chat-api
+    command: uvicorn src.backend.ai.chat_api:app --host 0.0.0.0 --port 8000 --reload
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    volumes:
+      - .:/app
+    depends_on:
+      - ollama
+
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    environment:
+      - OLLAMA_MODELS=mistral
+      - NVIDIA_VISIBLE_DEVICES=all # Enable all GPUs for Ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+volumes:
+  ollama-data:

--- a/docs/MODULARIZATION_AND_AI_PLAN.md
+++ b/docs/MODULARIZATION_AND_AI_PLAN.md
@@ -21,7 +21,7 @@
 
 | #   | Functionality         | Open Source | Local | Free | Recommended Server(s)                    |
 | --- | --------------------- | ----------- | ----- | ---- | ---------------------------------------- |
-| 1   | Observability/Tracing | Yes         | Yes   | Yes  | langfuse, pydanticai                     |
+| 1   | Observability/Tracing | Yes         | Yes   | Yes  | langfuse, pydanticai (Completed)         |
 | 2   | LLM/Chat              | Yes         | Yes   | Yes  | ollama-mcp-server, pydanticai-mcp-server |
 | 3   | Agent Orchestration   | Yes         | Yes   | Yes  | python-sdk-mcp, pydanticai-mcp-server    |
 | 4   | GitHub Automation     | Yes         | Yes   | Yes  | github-mcp-server                        |
@@ -40,8 +40,9 @@
 
 1. **Observability Foundation**
 
-   - Integrate Langfuse and Logfire for tracing, prompt management, and evaluation of all LLM, MCP, and agent interactions.
-   - Ensure all chatbots, agents, and MCP tool calls are logged and observable from the start.
+   - **Langfuse integration is complete.**
+   - All LLM, MCP, and agent interactions will be traced using Langfuse and (optionally) Logfire.
+   - All chatbots, agents, and MCP tool calls are now observable from the start.
 
 2. **AI Chat Agent Integration**
 

--- a/langfuse/README.md
+++ b/langfuse/README.md
@@ -1,0 +1,66 @@
+# Langfuse Local Setup Instructions
+
+This guide will help you run Langfuse locally as part of the Data_Insights repository for LLM and agent observability.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- At least 8GB RAM (16GB+ recommended for full stack)
+
+## Steps
+
+1. **Configure environment variables:**
+
+   - All environment variables for Langfuse and Data_Insights are managed in the root `.env` and `.env.example` files.
+   - Ensure the following Langfuse variables are present in your root `.env` and `.env.example`:
+     - `DATABASE_URL`, `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_MIGRATION_URL`, `REDIS_HOST`, `REDIS_PORT`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `LANGFUSE_HOST`, `SALT`, `S3_ENDPOINT`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_DEBUG`
+   - See `.env.example` for sample values and documentation.
+
+2. **Start Langfuse stack:**
+   Open a terminal in the `langfuse` directory and run:
+
+   ```cmd
+   docker-compose up -d
+   ```
+
+   This will start all required services (Langfuse web, worker, Postgres, Clickhouse, Redis, Minio).
+
+3. **Access the Langfuse UI:**
+   Open your browser to [http://localhost:3000](http://localhost:3000)
+
+4. **First-time setup:**
+
+   - Register an admin user in the UI.
+   - Create a project and API key for your Data_Insights integration.
+
+5. **Persistence:**
+
+   - All data is stored in Docker volumes under the `langfuse` directory.
+   - All environment variables are managed in the root `.env` and `.env.example` files for consistency across the project.
+
+6. **Stopping Langfuse:**
+   ```cmd
+   docker-compose down
+   ```
+
+## Troubleshooting
+
+- If you have issues, check logs with:
+  ```cmd
+  docker-compose logs
+  ```
+- Make sure ports 3000, 5433, 9000, 9001, 6379, and 8123 are not in use by other services.
+
+## Security Note
+
+- This setup is for local development only. Do not expose these services to the public internet without proper security hardening.
+
+## Integration Note
+
+- All environment variables for Langfuse are consolidated in the root `.env` and `.env.example` files. Do not create or use separate `.env` files in the `langfuse` directory.
+
+---
+
+---
+
+For more details, see the official Langfuse self-hosting documentation: https://langfuse.com/self-hosting

--- a/langfuse/docker-compose.yml
+++ b/langfuse/docker-compose.yml
@@ -1,0 +1,92 @@
+# Langfuse Docker Compose for Local Observability
+# This file is for local development and observability of LLMs and agents in Data_Insights.
+# All services run locally and data is stored in Docker volumes for persistence.
+
+version: "3.8"
+
+services:
+  langfuse-web:
+    image: langfuse/langfuse:2
+    ports:
+      - "3000:3000"
+    env_file:
+      - ../.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      clickhouse:
+        condition: service_started
+      redis:
+        condition: service_started
+      minio:
+        condition: service_started
+    volumes:
+      - langfuse-web-data:/data
+
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3
+    env_file:
+      - ../.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      clickhouse:
+        condition: service_started
+      redis:
+        condition: service_started
+      minio:
+        condition: service_started
+    volumes:
+      - langfuse-worker-data:/data
+
+  postgres:
+    image: postgres:15
+    env_file:
+      - ../.env
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:23.3
+    ports:
+      - "9000:9000"
+      - "8123:8123"
+    environment:
+      - CLICKHOUSE_DB=${CLICKHOUSE_DB}
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - "9002:9000" # Host 9002 -> Container 9000
+      - "9001:9001"
+    env_file:
+      - ../.env
+    volumes:
+      - minio-data:/data
+
+volumes:
+  langfuse-web-data:
+  langfuse-worker-data:
+  postgres-data:
+  clickhouse-data:
+  redis-data:
+  minio-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+fastapi
+uvicorn
 altair==5.5.0
 annotated-types==0.7.0
 anyio==4.9.0
@@ -48,6 +50,8 @@ requests==2.32.3
 rpds-py==0.24.0
 six==1.17.0
 smmap==5.0.2
+langfuse
+pydantic-ai
 sniffio==1.3.1
 SQLAlchemy==2.0.40
 streamlit==1.44.1

--- a/src/backend/ai/chat_api.py
+++ b/src/backend/ai/chat_api.py
@@ -1,0 +1,69 @@
+"""
+FastAPI-based chat endpoint for LLM/agent chat with Langfuse tracing.
+UI-agnostic: can be called from Streamlit, React, Shiny, etc.
+"""
+
+from fastapi import FastAPI, Request
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
+import httpx
+import os
+from config import get_ollama_config, get_langfuse_config, get_prompt_repo_path
+from .tracing import trace_llm_interaction
+
+app = FastAPI()
+
+# Pydantic model for chat requests
+class ChatRequest(BaseModel):
+    user_message: str
+    context: Optional[str] = ""
+    user_id: Optional[str] = None
+    session_id: Optional[str] = None
+
+class ChatResponse(BaseModel):
+    response: str
+    trace_id: Optional[str] = None
+
+# Helper to load prompt template
+PROMPT_TEMPLATE_PATH = os.path.join(get_prompt_repo_path(), "default_chat_prompt.txt")
+def load_prompt_template() -> str:
+    with open(PROMPT_TEMPLATE_PATH, "r", encoding="utf-8") as f:
+        return f.read()
+
+# Helper to call Ollama LLM
+async def call_ollama_llm(prompt: str, ollama_cfg: Dict[str, Any]) -> str:
+    url = f"{ollama_cfg['OLLAMA_BASE_URL']}/api/generate"
+    payload = {
+        "model": ollama_cfg["OLLAMA_MODEL"],
+        "prompt": prompt,
+        "temperature": ollama_cfg["TEMPERATURE"],
+        "max_tokens": ollama_cfg["MAX_TOKENS"],
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url, json=payload, timeout=60)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("response") or data.get("text") or "[No response]"
+
+@app.post("/api/chat", response_model=ChatResponse)
+async def chat_endpoint(request: ChatRequest):
+    ollama_cfg = get_ollama_config()
+    prompt_template = load_prompt_template()
+    prompt = prompt_template.format(
+        user_message=request.user_message,
+        context=request.context or ""
+    )
+    # Call LLM
+    llm_response = await call_ollama_llm(prompt, ollama_cfg)
+    # Trace interaction
+    trace = trace_llm_interaction(
+        input_prompt=prompt,
+        output=llm_response,
+        metadata={
+            "tool": "llm_chat",
+            "user_id": request.user_id,
+            "session_id": request.session_id,
+        }
+    )
+    trace_id = getattr(trace, "id", None) if trace else None
+    return ChatResponse(response=llm_response, trace_id=trace_id)

--- a/src/backend/ai/prompt_templates/default_chat_prompt.md
+++ b/src/backend/ai/prompt_templates/default_chat_prompt.md
@@ -1,0 +1,47 @@
+# Prompt Name: CaptureIntel Default Chat
+
+## Role
+
+CaptureIntel, an AI assistant for government contract data insights. Acts as a knowledgeable, concise, and helpful analyst for business development and capture management.
+
+## Task
+
+Answer user questions about government contracts, spending, agencies, NAICS codes, and related topics. Use provided context, data, and available tools to generate actionable insights, visualizations, or clear explanations.
+
+## Context
+
+- User message: `{user_message}`
+- Data context: `{context}`
+
+## Constraints
+
+- Remain concise and clear
+- Use only provided or local data (no external calls)
+- Respect privacy and security requirements
+- Avoid speculation; cite data when possible
+
+## Output
+
+Markdown-formatted answer. Use tables, bullet points, or code blocks as appropriate for clarity.
+
+## Examples
+
+- **Input:** Who are the top 5 contractors for NAICS 541330 in 2024?
+  **Output:**
+  | Rank | Contractor Name | Obligations ($) |
+  |------|----------------|-----------------|
+  | 1 | Acme Corp | 12,500,000 |
+  | 2 | Beta LLC | 10,200,000 |
+  | ... | ... | ... |
+
+- **Input:** What trends are visible in Army contract spending over the last 3 years?
+  **Output:**
+  - Army contract spending increased 8% year-over-year from 2022 to 2024.
+  - Largest growth in IT and logistics NAICS codes.
+  - See chart below for details.
+
+## Notes
+
+- If context is missing, ask the user for clarification.
+- If a question cannot be answered with available data, state this clearly.
+- Always format output for easy reading in dashboards or chat UIs.

--- a/src/backend/ai/tracing.py
+++ b/src/backend/ai/tracing.py
@@ -1,0 +1,90 @@
+"""
+Centralized tracing utilities for LLM, agent, and MCP tool observability.
+Loads all config from config.py (which reads from .env).
+"""
+
+import logging
+from typing import Any, Dict, Optional
+from config import get_app_config, get_ollama_config
+
+# Import Langfuse and Pydantic AI tracing if available
+try:
+    from langfuse import Langfuse
+    from pydantic_ai.tracing import Tracer as PydanticAITracer
+except ImportError:
+    Langfuse = None
+    PydanticAITracer = None
+    logging.warning("Langfuse or Pydantic AI not installed. Tracing will be disabled.")
+
+# Load tracing config from environment via config.py
+app_config = get_app_config()
+ollama_config = get_ollama_config()
+
+LANGFUSE_PUBLIC_KEY = app_config.get("LANGFUSE_PUBLIC_KEY") or None
+LANGFUSE_SECRET_KEY = app_config.get("LANGFUSE_SECRET_KEY") or None
+LANGFUSE_HOST = app_config.get("LANGFUSE_HOST", "http://localhost:3000")
+LANGFUSE_PROJECT = app_config.get("LANGFUSE_PROJECT", "default")
+LANGFUSE_ENVIRONMENT = app_config.get("LANGFUSE_ENVIRONMENT", "development")
+
+# Initialize Langfuse client (singleton)
+langfuse = None
+if Langfuse and LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY:
+    langfuse = Langfuse(
+        public_key=LANGFUSE_PUBLIC_KEY,
+        secret_key=LANGFUSE_SECRET_KEY,
+        host=LANGFUSE_HOST,
+        project=LANGFUSE_PROJECT,
+        environment=LANGFUSE_ENVIRONMENT,
+    )
+else:
+    logging.warning("Langfuse tracing is not fully configured or not installed.")
+
+# Initialize Pydantic AI tracer (optional)
+pydantic_ai_tracer = None
+if PydanticAITracer and langfuse:
+    pydantic_ai_tracer = PydanticAITracer(
+        langfuse_client=langfuse,
+        project=LANGFUSE_PROJECT,
+        environment=LANGFUSE_ENVIRONMENT,
+    )
+
+def trace_llm_interaction(input_prompt: str, output: str, metadata: Optional[Dict[str, Any]] = None):
+    """
+    Trace a single LLM or agent interaction.
+    Args:
+        input_prompt: The prompt sent to the LLM/agent.
+        output: The response from the LLM/agent.
+        metadata: Optional dict of extra context (user, tool, etc.)
+    """
+    if langfuse:
+        trace = langfuse.trace(
+            name=metadata.get('tool', 'llm_interaction') if metadata else 'llm_interaction',
+            input=input_prompt,
+            output=output,
+            metadata=metadata or {},
+        )
+        return trace
+    else:
+        logging.info(f"[Tracing Disabled] LLM interaction: {input_prompt[:80]} ... -> {output[:80]} ...")
+        return None
+
+def trace_pydantic_extraction(raw_output: str, parsed_result: Any, model_name: str, metadata: Optional[Dict[str, Any]] = None):
+    """
+    Trace a Pydantic AI extraction event.
+    Args:
+        raw_output: The raw LLM output.
+        parsed_result: The validated/parsed result.
+        model_name: Name of the Pydantic model used.
+        metadata: Optional dict of extra context.
+    """
+    if pydantic_ai_tracer:
+        trace = pydantic_ai_tracer.trace_extraction(
+            raw_output=raw_output,
+            parsed_result=parsed_result,
+            model_name=model_name,
+            metadata=metadata or {},
+        )
+        return trace
+    else:
+        logging.info(f"[Tracing Disabled] Pydantic extraction: {model_name} -> {parsed_result}")
+        return None


### PR DESCRIPTION
- Implement Dockerfile for FastAPI chat API.
- Create docker-compose setup for chat API and Ollama service.
- Add chat API endpoint with LLM interaction and tracing.
- Introduce prompt template for chat interactions.
- Centralize tracing utilities for observability.
- Update requirements to include Langfuse and Pydantic AI.
- Document Langfuse local setup instructions.
- Update modularization and AI integration roadmap.